### PR TITLE
11x11 boards in board picker, cursor rules

### DIFF
--- a/.cursor/rules/code-style.mdc
+++ b/.cursor/rules/code-style.mdc
@@ -1,0 +1,8 @@
+---
+alwaysApply: true
+---
+
+# Code Style
+
+- Keep code comment-free except for TODO comments which are allowed
+- Code should be self-documenting through clear naming and structure

--- a/src/ui/BoardComponent.tsx
+++ b/src/ui/BoardComponent.tsx
@@ -4,6 +4,7 @@ import { FaTimes, FaCheck } from "react-icons/fa";
 import { go } from "../game/gameController";
 import { ColorSet, getCurrentColorSet, isCustomPictureBoardEnabled } from "../content/boardStyles";
 import { isMobile } from "../utils/misc";
+import { generateBoardPattern } from "../utils/boardPatternGenerator";
 
 const CircularButton = styled.button`
   width: 50%;
@@ -121,12 +122,6 @@ const BoardComponent: React.FC = () => {
     };
   }, []);
 
-  const colorDarkSquare = currentColorSet.darkSquare;
-  const colorLightSquare = currentColorSet.lightSquare;
-  const colorManaPool = currentColorSet.manaPool;
-  const colorPickupItemSquare = currentColorSet.pickupItemSquare;
-  const colorSimpleManaSquare = currentColorSet.simpleManaSquare;
-
   const standardBoardTransform = "translate(0,100)";
   const pangchiuBoardTransform = "translate(83,184) scale(0.85892388)";
 
@@ -135,46 +130,13 @@ const BoardComponent: React.FC = () => {
       <svg xmlns="http://www.w3.org/2000/svg" className={`board-svg ${isGridVisible ? "grid-visible" : "grid-hidden"}`} viewBox="0 0 1100 1410" shapeRendering="crispEdges" overflow="visible">
         {isGridVisible ? (
           <g id="boardBackgroundLayer">
-            <rect y="100" width="1100" height="1100" fill={colorLightSquare} />
-            {Array.from({ length: 11 }, (_, row) =>
-              Array.from({ length: 11 }, (_, col) => {
-                const x = col * 100;
-                const y = (row + 1) * 100;
-                return (row + col) % 2 === 1 ? <rect key={`square-${row}-${col}`} x={x} y={y} width="100" height="100" fill={colorDarkSquare} /> : null;
-              })
-            )}
-
-            {[
-              [500, 600],
-              [0, 100],
-              [1000, 1100],
-              [1000, 100],
-              [0, 1100],
-            ].map(([x, y], i) => (
-              <rect key={`mana-pool-${i}`} x={x} y={y} width="100" height="100" fill={colorManaPool} />
-            ))}
-
-            {[
-              [0, 600],
-              [1000, 600],
-            ].map(([x, y], i) => (
-              <rect key={`pickup-${i}`} x={x} y={y} width="100" height="100" fill={colorPickupItemSquare} />
-            ))}
-
-            {[
-              [400, 400],
-              [600, 400],
-              [400, 800],
-              [600, 800],
-              [300, 500],
-              [500, 500],
-              [700, 500],
-              [300, 700],
-              [500, 700],
-              [700, 700],
-            ].map(([x, y], i) => (
-              <rect key={`simple-mana-${i}`} x={x} y={y} width="100" height="100" fill={colorSimpleManaSquare} />
-            ))}
+            {generateBoardPattern({
+              colorSet: currentColorSet,
+              size: 1100,
+              cellSize: 100,
+              offsetY: 100,
+              keyPrefix: "board",
+            })}
           </g>
         ) : (
           <g id="boardBackgroundLayer">

--- a/src/ui/BoardStylePicker.tsx
+++ b/src/ui/BoardStylePicker.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import { isMobile } from "../utils/misc";
 import { ColorSetKey, setBoardColorSet, getCurrentColorSetKey, colorSets } from "../content/boardStyles";
 import { updateBoardComponentForBoardStyleChange } from "./BoardComponent";
+import { generateBoardPattern } from "../utils/boardPatternGenerator";
 
 export const BoardStylePicker = styled.div`
   position: fixed;
@@ -36,9 +37,6 @@ export const ColorSquare = styled.button<{ isSelected?: boolean; colorSet: "ligh
   outline: none;
   padding: 0;
   overflow: hidden;
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  grid-template-rows: repeat(2, 1fr);
   background: #e0e0e0;
 
   @media (prefers-color-scheme: dark) {
@@ -56,12 +54,12 @@ export const ColorSquare = styled.button<{ isSelected?: boolean; colorSet: "ligh
   &:active {
     transform: scale(0.95);
   }
-`;
 
-const ColorSquareInner = styled.div<{ color: string }>`
-  width: 100%;
-  height: 100%;
-  background-color: ${(props) => props.color};
+  svg {
+    width: 100%;
+    height: 100%;
+    border-radius: 4px;
+  }
 `;
 
 const BoardStylePickerComponent: React.FC = () => {
@@ -75,15 +73,18 @@ const BoardStylePickerComponent: React.FC = () => {
 
   const renderColorSquares = (colorSet: "light" | "dark") => {
     const colors = colorSet === "light" ? colorSets.default : colorSets.darkAndYellow;
-    const { darkSquare, lightSquare, manaPool, pickupItemSquare } = colors;
+    const cellSize = 40 / 11;
 
     return (
-      <>
-        <ColorSquareInner color={darkSquare} />
-        <ColorSquareInner color={lightSquare} />
-        <ColorSquareInner color={manaPool} />
-        <ColorSquareInner color={pickupItemSquare} />
-      </>
+      <svg viewBox="0 0 40 40" width="40" height="40">
+        {generateBoardPattern({
+          colorSet: colors,
+          size: 40,
+          cellSize: cellSize,
+          offsetY: 0,
+          keyPrefix: `preview-${colorSet}`,
+        })}
+      </svg>
     );
   };
 

--- a/src/utils/boardPatternGenerator.tsx
+++ b/src/utils/boardPatternGenerator.tsx
@@ -1,0 +1,76 @@
+import React from "react";
+import { ColorSet } from "../content/boardStyles";
+
+export interface BoardPatternProps {
+  colorSet: ColorSet;
+  size: number;
+  cellSize: number;
+  offsetY?: number;
+  keyPrefix?: string;
+}
+
+export const generateBoardPattern = ({ colorSet, size, cellSize, offsetY = 0, keyPrefix = "square" }: BoardPatternProps): React.JSX.Element[] => {
+  const elements: React.JSX.Element[] = [];
+
+  elements.push(<rect key={`${keyPrefix}-background`} y={offsetY} width={size} height={size} fill={colorSet.lightSquare} />);
+
+  for (let row = 0; row < 11; row++) {
+    for (let col = 0; col < 11; col++) {
+      if ((row + col) % 2 === 1) {
+        const x = col * cellSize;
+        const y = row * cellSize + offsetY;
+        elements.push(<rect key={`${keyPrefix}-${row}-${col}`} x={x} y={y} width={cellSize} height={cellSize} fill={colorSet.darkSquare} />);
+      }
+    }
+  }
+
+  const manaPoolPositions = [
+    [5, 5],
+    [0, 0],
+    [10, 10],
+    [10, 0],
+    [0, 10],
+  ];
+
+  manaPoolPositions.forEach(([col, row], i) => {
+    const x = col * cellSize;
+    const y = row * cellSize + offsetY;
+    elements.push(<rect key={`${keyPrefix}-mana-pool-${i}`} x={x} y={y} width={cellSize} height={cellSize} fill={colorSet.manaPool} />);
+  });
+
+  const pickupPositions = [
+    [0, 5],
+    [10, 5],
+  ];
+
+  pickupPositions.forEach(([col, row], i) => {
+    const x = col * cellSize;
+    const y = row * cellSize + offsetY;
+    elements.push(<rect key={`${keyPrefix}-pickup-${i}`} x={x} y={y} width={cellSize} height={cellSize} fill={colorSet.pickupItemSquare} />);
+  });
+
+  const simpleManaPositions = [
+    [4, 3],
+    [6, 3],
+    [4, 7],
+    [6, 7],
+    [3, 4],
+    [5, 4],
+    [7, 4],
+    [3, 6],
+    [5, 6],
+    [7, 6],
+  ];
+
+  simpleManaPositions.forEach(([col, row], i) => {
+    const x = col * cellSize;
+    const y = row * cellSize + offsetY;
+    elements.push(<rect key={`${keyPrefix}-simple-mana-${i}`} x={x} y={y} width={cellSize} height={cellSize} fill={colorSet.simpleManaSquare} />);
+  });
+
+  return elements;
+};
+
+export const generateBoardPatternGroup = (props: BoardPatternProps): React.JSX.Element => {
+  return <g>{generateBoardPattern(props)}</g>;
+};


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added 11x11 board previews to the board style picker and refactored board rendering to use a shared pattern generator.

- **Refactors**
  - Moved board SVG pattern logic to a new utility for reuse in both the main board and picker previews.
  - Added a code style rule file to enforce comment usage guidelines.

<!-- End of auto-generated description by cubic. -->

