### PR TITLE
optimize event syncs

### DIFF
--- a/cloud/README.md
+++ b/cloud/README.md
@@ -45,3 +45,5 @@ Detailed rollout sequence and checks: `../docs/auth-rollout.md`
 X provider setup and deploy checklist: `../docs/x-auth-deploy.md`
 
 Username migration note: run `backfillUsernameIndexCaseInsensitive.js --write` to backfill `usernameIndex` + `users.usernameLookupKey`, then confirm `strictUniquenessReady: true` before relying on strict case-insensitive username uniqueness.
+
+Cloud Monitoring reliability alerts setup: `../docs/cloud-monitoring-alerts.md`

--- a/cloud/functions/eventProjector.js
+++ b/cloud/functions/eventProjector.js
@@ -69,27 +69,63 @@ const getListSortAtMs = (eventData, status) => {
   if (status === "ended") {
     return typeof eventData.endedAtMs === "number"
       ? Math.floor(eventData.endedAtMs)
-      : typeof eventData.updatedAtMs === "number"
-        ? Math.floor(eventData.updatedAtMs)
-        : Date.now();
+      : typeof eventData.startAtMs === "number"
+        ? Math.floor(eventData.startAtMs)
+        : typeof eventData.createdAtMs === "number"
+          ? Math.floor(eventData.createdAtMs)
+          : 1;
   }
   if (status === "dismissed") {
     return typeof eventData.endedAtMs === "number"
       ? Math.floor(eventData.endedAtMs)
-      : typeof eventData.updatedAtMs === "number"
-        ? Math.floor(eventData.updatedAtMs)
-        : Date.now();
+      : typeof eventData.startAtMs === "number"
+        ? Math.floor(eventData.startAtMs)
+        : typeof eventData.createdAtMs === "number"
+          ? Math.floor(eventData.createdAtMs)
+          : 1;
   }
   const startAtMs =
     typeof eventData.startAtMs === "number"
       ? Math.floor(eventData.startAtMs)
       : null;
   if (startAtMs === null || !Number.isFinite(startAtMs) || startAtMs <= 0) {
-    return Date.now();
+    return typeof eventData.createdAtMs === "number"
+      ? Math.floor(eventData.createdAtMs)
+      : 1;
   }
   // Firestore pagination is listSortAt DESC. Map upcoming start times so sooner events
   // receive larger listSortAt values, keeping paging and in-app ordering aligned.
   return Math.min(MAX_TIMESTAMP_MS, Math.max(1, MAX_TIMESTAMP_MS - startAtMs));
+};
+
+const buildProjectionFingerprint = (eventData) => {
+  if (!eventData || typeof eventData !== "object") {
+    return "null";
+  }
+  const participants =
+    eventData.participants && typeof eventData.participants === "object"
+      ? eventData.participants
+      : {};
+  const status = mapEventStatusToNavigationStatus(
+    normalizeString(eventData.status),
+  );
+  const fullPreviewParticipants = buildPreviewParticipants(participants);
+  const participantPreview = fullPreviewParticipants.slice(
+    0,
+    NAVIGATION_PARTICIPANT_PREVIEW_LIMIT,
+  );
+  const ownerProfileIds = getOwnerProfileIds(participants).sort();
+  return JSON.stringify({
+    status,
+    sortBucket: SORT_BUCKETS[status],
+    listSortAtMs: getListSortAtMs(eventData, status),
+    startAtMs: normalizeFiniteNumberOrNull(eventData.startAtMs),
+    endedAtMs: normalizeFiniteNumberOrNull(eventData.endedAtMs),
+    winnerDisplayName: normalizeString(eventData.winnerDisplayName),
+    participantCount: fullPreviewParticipants.length,
+    participantPreview,
+    ownerProfileIds,
+  });
 };
 
 const buildPreviewParticipants = (participants) => {
@@ -213,17 +249,31 @@ async function projectEvent(eventId, beforeData, afterData) {
   await commitBatchIfNeeded(true);
 }
 
-const onEventWritten = onValueWritten("/events/{eventId}", async (event) => {
-  const eventId = normalizeString(event.params.eventId);
-  if (!eventId) {
-    return;
-  }
-  const beforeData = event.data.before.exists()
-    ? event.data.before.val()
-    : null;
-  const afterData = event.data.after.exists() ? event.data.after.val() : null;
-  await projectEvent(eventId, beforeData, afterData);
-});
+const onEventWritten = onValueWritten(
+  {
+    ref: "/events/{eventId}",
+    maxInstances: 10,
+    concurrency: 40,
+    memory: "256MiB",
+    cpu: 1,
+  },
+  async (event) => {
+    const eventId = normalizeString(event.params.eventId);
+    if (!eventId) {
+      return;
+    }
+    const beforeData = event.data.before.exists()
+      ? event.data.before.val()
+      : null;
+    const afterData = event.data.after.exists() ? event.data.after.val() : null;
+    const beforeFingerprint = buildProjectionFingerprint(beforeData);
+    const afterFingerprint = buildProjectionFingerprint(afterData);
+    if (beforeFingerprint === afterFingerprint) {
+      return;
+    }
+    await projectEvent(eventId, beforeData, afterData);
+  },
+);
 
 module.exports = {
   onEventWritten,

--- a/cloud/functions/events.js
+++ b/cloud/functions/events.js
@@ -13,7 +13,8 @@ const INITIAL_FEN =
 const EVENT_SCHEMA_VERSION = 2;
 const EVENT_LOCK_TTL_MS = 30 * 1000;
 const EVENT_LOCK_REFRESH_INTERVAL_MS = 10 * 1000;
-const EVENT_MATCH_RESOLVE_CONCURRENCY = 12;
+const EVENT_MATCH_RESOLVE_CONCURRENCY = 4;
+const EVENT_SYNC_THROTTLE_WINDOW_MS = 500;
 const MIN_STARTS_IN_MINUTES = 1;
 const MAX_STARTS_IN_MINUTES = 7 * 24 * 60;
 const MAX_EVENT_PARTICIPANTS = 32;
@@ -87,6 +88,57 @@ const getParticipantIds = (event) => {
     (profileId) =>
       participants[profileId] && typeof participants[profileId] === "object",
   );
+};
+
+const resolveRequesterParticipation = (event, auth) => {
+  const participants =
+    event && event.participants && typeof event.participants === "object"
+      ? event.participants
+      : {};
+  const requesterUid = normalizeString(auth && auth.uid);
+  const claimedProfileId = normalizeString(
+    auth && auth.token ? auth.token.profileId : "",
+  );
+  if (
+    claimedProfileId &&
+    participants[claimedProfileId] &&
+    typeof participants[claimedProfileId] === "object"
+  ) {
+    return {
+      isParticipant: true,
+      profileId: claimedProfileId,
+    };
+  }
+  for (const [profileId, participant] of Object.entries(participants)) {
+    if (!participant || typeof participant !== "object") {
+      continue;
+    }
+    if (
+      claimedProfileId &&
+      normalizeString(participant.profileId) === claimedProfileId
+    ) {
+      return {
+        isParticipant: true,
+        profileId,
+      };
+    }
+    if (normalizeString(participant.loginUid) === requesterUid) {
+      return {
+        isParticipant: true,
+        profileId,
+      };
+    }
+  }
+  if (normalizeString(event && event.createdByLoginUid) === requesterUid) {
+    return {
+      isParticipant: true,
+      profileId: normalizeString(event && event.createdByProfileId) || null,
+    };
+  }
+  return {
+    isParticipant: false,
+    profileId: null,
+  };
 };
 
 const buildParticipantSnapshot = (profile, loginUid, joinedAtMs) => {
@@ -1146,6 +1198,48 @@ const releaseEventLock = async (lockHandle) => {
   }
 };
 
+const tryAcquireEventSyncThrottle = async (eventId, ownerUid) => {
+  const throttleRef = admin.database().ref(`eventSyncThrottles/${eventId}`);
+  const nowMs = getNowMs();
+  const token = randomString(10);
+  const result = await throttleRef.transaction((current) => {
+    const lastStartedAtMs =
+      current && typeof current.startedAtMs === "number"
+        ? Math.floor(current.startedAtMs)
+        : 0;
+    if (
+      lastStartedAtMs > 0 &&
+      nowMs - lastStartedAtMs < EVENT_SYNC_THROTTLE_WINDOW_MS
+    ) {
+      return;
+    }
+    return {
+      startedAtMs: nowMs,
+      ownerUid,
+      token,
+    };
+  });
+  if (!result.committed) {
+    return null;
+  }
+  return {
+    startedAtMs: nowMs,
+    ownerUid,
+    token,
+  };
+};
+
+const logSyncEventStateResult = (payload) => {
+  try {
+    console.log("event:sync:result", payload);
+  } catch (error) {
+    console.error(
+      "event:sync:result:log:error",
+      error && error.message ? error.message : error,
+    );
+  }
+};
+
 exports.createEvent = onCall(async (request) => {
   if (!request.auth) {
     throw new HttpsError(
@@ -1309,261 +1403,355 @@ exports.joinEvent = onCall(async (request) => {
   }
 });
 
-exports.syncEventState = onCall(async (request) => {
-  if (!request.auth) {
-    throw new HttpsError(
-      "unauthenticated",
-      "The function must be called while authenticated.",
-    );
-  }
+exports.syncEventState = onCall(
+  {
+    maxInstances: 20,
+    concurrency: 20,
+    memory: "512MiB",
+    timeoutSeconds: 30,
+  },
+  async (request) => {
+    const startedAtMs = getNowMs();
+    const syncLog = {
+      eventId: null,
+      requesterUid: request && request.auth ? request.auth.uid : null,
+      requesterProfileId: null,
+      skipped: false,
+      reason: null,
+      didChange: false,
+      durationMs: 0,
+    };
 
-  const eventId = normalizeString(request.data && request.data.eventId);
-  if (!eventId) {
-    throw new HttpsError("invalid-argument", "eventId is required.");
-  }
+    let lockHandle = null;
+    let stopLockHeartbeat = () => {};
 
-  const lockHandle = await acquireEventLockWithRetry(
-    eventId,
-    request.auth.uid,
-    {
-      attempts: 10,
-      delayMs: 100,
-    },
-  );
-  if (!lockHandle) {
-    return { ok: true, eventId, skipped: true, reason: "locked" };
-  }
-  const stopLockHeartbeat = startEventLockHeartbeat(lockHandle);
-
-  try {
-    const eventSnapshot = await admin
-      .database()
-      .ref(`events/${eventId}`)
-      .once("value");
-    if (!eventSnapshot.exists()) {
-      throw new HttpsError("not-found", "Event not found.");
-    }
-    const event = cloneValue(eventSnapshot.val() || {});
-    const nowMs = getNowMs();
-    const updates = {};
-    let didChange = false;
-
-    if (event.status === "scheduled") {
-      const dueTransition = buildScheduledEventDueUpdates({
-        eventId,
-        event,
-        nowMs,
-      });
-      Object.assign(updates, dueTransition.updates);
-      didChange = dueTransition.didChange;
-    } else if (event.status === "active") {
-      const normalizedOriginalCurrentRoundIndex = toFiniteInteger(
-        event.currentRoundIndex,
-        NaN,
-      );
-      const originalCurrentRoundIndex = Number.isFinite(
-        normalizedOriginalCurrentRoundIndex,
-      )
-        ? normalizedOriginalCurrentRoundIndex
-        : null;
-      const originalStatus = normalizeString(event.status) || "active";
-      const originalEndedAtMs =
-        typeof event.endedAtMs === "number"
-          ? Math.floor(event.endedAtMs)
-          : null;
-      const originalWinnerProfileId = normalizeStringOrNull(
-        event.winnerProfileId,
-      );
-      const originalWinnerDisplayName = normalizeStringOrNull(
-        event.winnerDisplayName,
-      );
-      const rounds = cloneValue(
-        event.rounds && typeof event.rounds === "object" ? event.rounds : {},
-      );
-      let participants = cloneValue(
-        event.participants && typeof event.participants === "object"
-          ? event.participants
-          : {},
-      );
-      const inviteUpdates = {};
-      let roundsChanged = false;
-      let participantsChanged = false;
-      const sortedRoundIndexes = getSortedRoundIndexes(rounds);
-      for (const roundIndex of sortedRoundIndexes) {
-        const round = rounds[String(roundIndex)];
-        if (!round || !round.matches || typeof round.matches !== "object") {
-          continue;
-        }
-        const resolvedEntries = await resolveRoundMatchesWithConcurrency(
-          round.matches,
+    try {
+      if (!request.auth) {
+        throw new HttpsError(
+          "unauthenticated",
+          "The function must be called while authenticated.",
         );
-        for (const entry of resolvedEntries) {
-          const { matchRecord, resolved } = entry;
-          if (!resolved) {
-            continue;
-          }
-          if (applyMatchResolution(matchRecord, resolved, nowMs)) {
-            roundsChanged = true;
-          }
-        }
       }
 
-      if (
-        reconcileBracketMatchReadiness({
-          eventId,
-          rounds,
-          nowMs,
-          participantsById: participants,
-          inviteUpdates,
-        })
-      ) {
-        roundsChanged = true;
+      const eventId = normalizeString(request.data && request.data.eventId);
+      if (!eventId) {
+        throw new HttpsError("invalid-argument", "eventId is required.");
       }
+      syncLog.eventId = eventId;
 
-      const {
-        didChange: roundStatusChanged,
-        finalRoundIndex,
-        earliestUnresolvedRoundIndex,
-        finalRoundWinnerProfileId,
-      } = recomputeRoundStatuses({
-        rounds,
-        nowMs,
-      });
-      if (roundStatusChanged) {
-        roundsChanged = true;
+      const eventSnapshot = await admin
+        .database()
+        .ref(`events/${eventId}`)
+        .once("value");
+      if (!eventSnapshot.exists()) {
+        throw new HttpsError("not-found", "Event not found.");
       }
+      const initialEvent = cloneValue(eventSnapshot.val() || {});
 
-      const eventShouldEnd = normalizeString(finalRoundWinnerProfileId) !== "";
-      const winnerProfileId = eventShouldEnd ? finalRoundWinnerProfileId : null;
-      const nextCurrentRoundIndex =
-        earliestUnresolvedRoundIndex !== null
-          ? earliestUnresolvedRoundIndex
-          : finalRoundIndex;
-      event.currentRoundIndex = nextCurrentRoundIndex;
-
-      const participantStateResult = rebuildParticipantStatesFromRounds({
-        participantsById: participants,
-        rounds,
-        winnerProfileId,
-        eventEnded: eventShouldEnd,
-      });
-      if (participantStateResult.didChange) {
-        participants = participantStateResult.participantsById;
-        participantsChanged = true;
-      }
-
-      if (eventShouldEnd) {
-        const winnerParticipant =
-          (winnerProfileId && participants[winnerProfileId]) || null;
-        event.status = "ended";
-        if (typeof event.endedAtMs !== "number") {
-          event.endedAtMs = nowMs;
-        }
-        event.winnerProfileId = winnerProfileId;
-        event.winnerDisplayName = winnerParticipant
-          ? winnerParticipant.displayName
-          : null;
-      } else {
-        event.status = "active";
-        event.endedAtMs = null;
-        event.winnerProfileId = null;
-        event.winnerDisplayName = null;
-      }
-
-      let eventChanged = false;
-      const normalizedCurrentRoundIndex =
-        typeof event.currentRoundIndex === "number"
-          ? Math.floor(event.currentRoundIndex)
-          : null;
-      if (normalizedCurrentRoundIndex !== originalCurrentRoundIndex) {
-        updates[`events/${eventId}/currentRoundIndex`] =
-          normalizedCurrentRoundIndex;
-        eventChanged = true;
-      }
-
-      const normalizedStatus = normalizeString(event.status) || "active";
-      if (normalizedStatus !== originalStatus) {
-        updates[`events/${eventId}/status`] = normalizedStatus;
-        eventChanged = true;
-      }
-
-      const normalizedEndedAtMs =
-        typeof event.endedAtMs === "number"
-          ? Math.floor(event.endedAtMs)
-          : null;
-      if (normalizedEndedAtMs !== originalEndedAtMs) {
-        updates[`events/${eventId}/endedAtMs`] = normalizedEndedAtMs;
-        eventChanged = true;
-      }
-
-      const normalizedWinnerProfileId = normalizeStringOrNull(
-        event.winnerProfileId,
+      const requesterParticipation = resolveRequesterParticipation(
+        initialEvent,
+        request.auth,
       );
-      if (normalizedWinnerProfileId !== originalWinnerProfileId) {
-        updates[`events/${eventId}/winnerProfileId`] =
-          normalizedWinnerProfileId;
-        eventChanged = true;
-      }
-
-      const normalizedWinnerDisplayName = normalizeStringOrNull(
-        event.winnerDisplayName,
-      );
-      if (normalizedWinnerDisplayName !== originalWinnerDisplayName) {
-        updates[`events/${eventId}/winnerDisplayName`] =
-          normalizedWinnerDisplayName;
-        eventChanged = true;
-      }
-
-      if (roundsChanged) {
-        updates[`events/${eventId}/rounds`] = rounds;
-      }
-      if (participantsChanged) {
-        updates[`events/${eventId}/participants`] = participants;
-      }
-      if (Object.keys(inviteUpdates).length > 0) {
-        Object.assign(updates, inviteUpdates);
-      }
-      if (
-        roundsChanged ||
-        participantsChanged ||
-        Object.keys(inviteUpdates).length > 0 ||
-        eventChanged
-      ) {
-        updates[`events/${eventId}/updatedAtMs`] = nowMs;
-        didChange = true;
-      }
-    }
-
-    if (didChange) {
-      const lockOwned = await isEventLockStillOwned(lockHandle);
-      if (!lockOwned) {
-        const latestSnapshot = await admin
-          .database()
-          .ref(`events/${eventId}`)
-          .once("value");
+      syncLog.requesterProfileId = requesterParticipation.profileId;
+      if (!requesterParticipation.isParticipant) {
+        syncLog.skipped = true;
+        syncLog.reason = "not-participant";
         return {
           ok: true,
           eventId,
           skipped: true,
-          reason: "lock-lost",
-          event: latestSnapshot.val(),
+          reason: "not-participant",
         };
       }
-      await admin.database().ref().update(updates);
-    }
 
-    const refreshedSnapshot = await admin
-      .database()
-      .ref(`events/${eventId}`)
-      .once("value");
-    return {
-      ok: true,
-      eventId,
-      didChange,
-      event: refreshedSnapshot.val(),
-    };
-  } finally {
-    stopLockHeartbeat();
-    await releaseEventLock(lockHandle);
-  }
-});
+      const syncThrottle = await tryAcquireEventSyncThrottle(
+        eventId,
+        request.auth.uid,
+      );
+      if (!syncThrottle) {
+        syncLog.skipped = true;
+        syncLog.reason = "rate-limited";
+        return {
+          ok: true,
+          eventId,
+          skipped: true,
+          reason: "rate-limited",
+        };
+      }
+
+      lockHandle = await acquireEventLockWithRetry(eventId, request.auth.uid, {
+        attempts: 10,
+        delayMs: 100,
+      });
+      if (!lockHandle) {
+        syncLog.skipped = true;
+        syncLog.reason = "locked";
+        return { ok: true, eventId, skipped: true, reason: "locked" };
+      }
+      stopLockHeartbeat = startEventLockHeartbeat(lockHandle);
+
+      const lockedEventSnapshot = await admin
+        .database()
+        .ref(`events/${eventId}`)
+        .once("value");
+      if (!lockedEventSnapshot.exists()) {
+        throw new HttpsError("not-found", "Event not found.");
+      }
+      const event = cloneValue(lockedEventSnapshot.val() || {});
+      const lockedRequesterParticipation = resolveRequesterParticipation(
+        event,
+        request.auth,
+      );
+      syncLog.requesterProfileId = lockedRequesterParticipation.profileId;
+      if (!lockedRequesterParticipation.isParticipant) {
+        syncLog.skipped = true;
+        syncLog.reason = "not-participant";
+        return {
+          ok: true,
+          eventId,
+          skipped: true,
+          reason: "not-participant",
+        };
+      }
+      const nowMs = getNowMs();
+      const updates = {};
+      let didChange = false;
+
+      if (event.status === "scheduled") {
+        const dueTransition = buildScheduledEventDueUpdates({
+          eventId,
+          event,
+          nowMs,
+        });
+        Object.assign(updates, dueTransition.updates);
+        didChange = dueTransition.didChange;
+      } else if (event.status === "active") {
+        const normalizedOriginalCurrentRoundIndex = toFiniteInteger(
+          event.currentRoundIndex,
+          NaN,
+        );
+        const originalCurrentRoundIndex = Number.isFinite(
+          normalizedOriginalCurrentRoundIndex,
+        )
+          ? normalizedOriginalCurrentRoundIndex
+          : null;
+        const originalStatus = normalizeString(event.status) || "active";
+        const originalEndedAtMs =
+          typeof event.endedAtMs === "number"
+            ? Math.floor(event.endedAtMs)
+            : null;
+        const originalWinnerProfileId = normalizeStringOrNull(
+          event.winnerProfileId,
+        );
+        const originalWinnerDisplayName = normalizeStringOrNull(
+          event.winnerDisplayName,
+        );
+        const rounds = cloneValue(
+          event.rounds && typeof event.rounds === "object" ? event.rounds : {},
+        );
+        let participants = cloneValue(
+          event.participants && typeof event.participants === "object"
+            ? event.participants
+            : {},
+        );
+        const inviteUpdates = {};
+        let roundsChanged = false;
+        let participantsChanged = false;
+        const sortedRoundIndexes = getSortedRoundIndexes(rounds);
+        for (const roundIndex of sortedRoundIndexes) {
+          const round = rounds[String(roundIndex)];
+          if (!round || !round.matches || typeof round.matches !== "object") {
+            continue;
+          }
+          const resolvedEntries = await resolveRoundMatchesWithConcurrency(
+            round.matches,
+          );
+          for (const entry of resolvedEntries) {
+            const { matchRecord, resolved } = entry;
+            if (!resolved) {
+              continue;
+            }
+            if (applyMatchResolution(matchRecord, resolved, nowMs)) {
+              roundsChanged = true;
+            }
+          }
+        }
+
+        if (
+          reconcileBracketMatchReadiness({
+            eventId,
+            rounds,
+            nowMs,
+            participantsById: participants,
+            inviteUpdates,
+          })
+        ) {
+          roundsChanged = true;
+        }
+
+        const {
+          didChange: roundStatusChanged,
+          finalRoundIndex,
+          earliestUnresolvedRoundIndex,
+          finalRoundWinnerProfileId,
+        } = recomputeRoundStatuses({
+          rounds,
+          nowMs,
+        });
+        if (roundStatusChanged) {
+          roundsChanged = true;
+        }
+
+        const eventShouldEnd =
+          normalizeString(finalRoundWinnerProfileId) !== "";
+        const winnerProfileId = eventShouldEnd
+          ? finalRoundWinnerProfileId
+          : null;
+        const nextCurrentRoundIndex =
+          earliestUnresolvedRoundIndex !== null
+            ? earliestUnresolvedRoundIndex
+            : finalRoundIndex;
+        event.currentRoundIndex = nextCurrentRoundIndex;
+
+        const participantStateResult = rebuildParticipantStatesFromRounds({
+          participantsById: participants,
+          rounds,
+          winnerProfileId,
+          eventEnded: eventShouldEnd,
+        });
+        if (participantStateResult.didChange) {
+          participants = participantStateResult.participantsById;
+          participantsChanged = true;
+        }
+
+        if (eventShouldEnd) {
+          const winnerParticipant =
+            (winnerProfileId && participants[winnerProfileId]) || null;
+          event.status = "ended";
+          if (typeof event.endedAtMs !== "number") {
+            event.endedAtMs = nowMs;
+          }
+          event.winnerProfileId = winnerProfileId;
+          event.winnerDisplayName = winnerParticipant
+            ? winnerParticipant.displayName
+            : null;
+        } else {
+          event.status = "active";
+          event.endedAtMs = null;
+          event.winnerProfileId = null;
+          event.winnerDisplayName = null;
+        }
+
+        let eventChanged = false;
+        const normalizedCurrentRoundIndex =
+          typeof event.currentRoundIndex === "number"
+            ? Math.floor(event.currentRoundIndex)
+            : null;
+        if (normalizedCurrentRoundIndex !== originalCurrentRoundIndex) {
+          updates[`events/${eventId}/currentRoundIndex`] =
+            normalizedCurrentRoundIndex;
+          eventChanged = true;
+        }
+
+        const normalizedStatus = normalizeString(event.status) || "active";
+        if (normalizedStatus !== originalStatus) {
+          updates[`events/${eventId}/status`] = normalizedStatus;
+          eventChanged = true;
+        }
+
+        const normalizedEndedAtMs =
+          typeof event.endedAtMs === "number"
+            ? Math.floor(event.endedAtMs)
+            : null;
+        if (normalizedEndedAtMs !== originalEndedAtMs) {
+          updates[`events/${eventId}/endedAtMs`] = normalizedEndedAtMs;
+          eventChanged = true;
+        }
+
+        const normalizedWinnerProfileId = normalizeStringOrNull(
+          event.winnerProfileId,
+        );
+        if (normalizedWinnerProfileId !== originalWinnerProfileId) {
+          updates[`events/${eventId}/winnerProfileId`] =
+            normalizedWinnerProfileId;
+          eventChanged = true;
+        }
+
+        const normalizedWinnerDisplayName = normalizeStringOrNull(
+          event.winnerDisplayName,
+        );
+        if (normalizedWinnerDisplayName !== originalWinnerDisplayName) {
+          updates[`events/${eventId}/winnerDisplayName`] =
+            normalizedWinnerDisplayName;
+          eventChanged = true;
+        }
+
+        if (roundsChanged) {
+          updates[`events/${eventId}/rounds`] = rounds;
+        }
+        if (participantsChanged) {
+          updates[`events/${eventId}/participants`] = participants;
+        }
+        if (Object.keys(inviteUpdates).length > 0) {
+          Object.assign(updates, inviteUpdates);
+        }
+        if (
+          roundsChanged ||
+          participantsChanged ||
+          Object.keys(inviteUpdates).length > 0 ||
+          eventChanged
+        ) {
+          updates[`events/${eventId}/updatedAtMs`] = nowMs;
+          didChange = true;
+        }
+      }
+
+      if (didChange) {
+        const lockOwned = await isEventLockStillOwned(lockHandle);
+        if (!lockOwned) {
+          const latestSnapshot = await admin
+            .database()
+            .ref(`events/${eventId}`)
+            .once("value");
+          syncLog.skipped = true;
+          syncLog.reason = "locked";
+          return {
+            ok: true,
+            eventId,
+            skipped: true,
+            reason: "locked",
+            event: latestSnapshot.val(),
+          };
+        }
+        await admin.database().ref().update(updates);
+      }
+
+      const refreshedSnapshot = await admin
+        .database()
+        .ref(`events/${eventId}`)
+        .once("value");
+      syncLog.didChange = didChange;
+      return {
+        ok: true,
+        eventId,
+        didChange,
+        event: refreshedSnapshot.val(),
+      };
+    } catch (error) {
+      if (!syncLog.reason) {
+        syncLog.reason =
+          error && typeof error === "object" && "code" in error
+            ? String(error.code)
+            : "error";
+      }
+      throw error;
+    } finally {
+      if (lockHandle) {
+        stopLockHeartbeat();
+        await releaseEventLock(lockHandle);
+      }
+      syncLog.durationMs = getNowMs() - startedAtMs;
+      logSyncEventStateResult(syncLog);
+    }
+  },
+);

--- a/docs/cloud-monitoring-alerts.md
+++ b/docs/cloud-monitoring-alerts.md
@@ -1,0 +1,59 @@
+# Cloud Monitoring Alerts (Functions Reliability)
+
+Use these commands to create the reliability alerts for `mons-link`.
+
+## 1) Log-based metric for CPU allocation quota errors
+
+```bash
+PROJECT_ID="mons-link"
+
+gcloud logging metrics create cf_cpu_allocation_quota_exceeded \
+  --project "${PROJECT_ID}" \
+  --description "Cloud Run request failures caused by CPU allocation quota exhaustion" \
+  --log-filter "resource.type=\"cloud_run_revision\" AND logName=\"projects/${PROJECT_ID}/logs/run.googleapis.com%2Frequests\" AND textPayload:\"run.googleapis.com/cpu_allocation\""
+```
+
+## 2) Log-based metrics for function errors
+
+```bash
+PROJECT_ID="mons-link"
+
+gcloud logging metrics create cf_sync_event_state_errors \
+  --project "${PROJECT_ID}" \
+  --description "Error logs for syncEventState callable" \
+  --log-filter "resource.type=\"cloud_run_revision\" AND labels.goog-drz-cloudfunctions-id=\"synceventstate\" AND severity>=ERROR"
+
+gcloud logging metrics create cf_event_projector_errors \
+  --project "${PROJECT_ID}" \
+  --description "Error logs for projectProfileGamesOnEventWritten trigger" \
+  --log-filter "resource.type=\"cloud_run_revision\" AND labels.goog-drz-cloudfunctions-id=\"projectprofilegamesoneventwritten\" AND severity>=ERROR"
+```
+
+## 3) Create alert policies from the metrics
+
+Create one policy per metric in Google Cloud Monitoring:
+
+1. Condition type: `Metric Threshold`
+2. Metric: logging user metric
+3. Trigger: `Any time series violates`
+4. Threshold:
+   - `cf_cpu_allocation_quota_exceeded`: `>= 1` in `5m`
+   - `cf_sync_event_state_errors`: `>= 3` in `5m`
+   - `cf_event_projector_errors`: `>= 3` in `5m`
+5. Notifications: add your on-call channel(s)
+
+## 4) Dashboard for skip-reason distribution
+
+Create a Logs Explorer query and save as chart:
+
+```text
+logName="projects/mons-link/logs/run.googleapis.com%2Fstdout"
+textPayload:"event:sync:result"
+```
+
+Group by JSON payload fields:
+
+- `jsonPayload.reason`
+- `jsonPayload.skipped`
+
+This chart is used to tune `rate-limited` / `locked` behavior after rollout.

--- a/src/connection/connection.ts
+++ b/src/connection/connection.ts
@@ -137,6 +137,11 @@ const normalizeMiningData = (source: any): PlayerMiningData => {
 const controllerVersion = 2;
 const LEADERBOARD_ENTRY_LIMIT = 99;
 const wagerDebugLogsEnabled = process.env.NODE_ENV !== "production";
+const EVENT_SYNC_COOLDOWN_ACTIVE_MS = 700;
+const EVENT_SYNC_COOLDOWN_SCHEDULED_MS = 1500;
+const EVENT_SYNC_PARTICIPANT_CACHE_TTL_MS = 3000;
+const EVENT_SYNC_PARTICIPANT_NEGATIVE_CACHE_TTL_MS = 800;
+const EVENT_SYNC_RETRY_DELAYS_MS = [150, 300] as const;
 
 export type NavigationGamesPageCursor =
   QueryDocumentSnapshot<DocumentData> | null;
@@ -159,6 +164,27 @@ type MatchRuntimeContext = {
   role: InviteRole;
   canWrite: boolean;
   createdAtMs: number;
+};
+
+type EventSyncSkipReason = "locked" | "rate-limited" | "not-participant";
+
+type EventSyncResponse = {
+  ok: boolean;
+  didChange?: boolean;
+  skipped?: boolean;
+  reason?: EventSyncSkipReason;
+  event?: EventRecord | null;
+};
+
+type EventSyncParticipantMembershipCacheEntry = {
+  profileId: string;
+  checkedAtMs: number;
+  isParticipant: boolean;
+};
+
+type EventSyncCooldownCacheEntry = {
+  responseAtMs: number;
+  response: EventSyncResponse;
 };
 
 const getRouteStateSnapshot = () => getCurrentRouteState();
@@ -235,15 +261,17 @@ class Connection {
     inviteId: string;
     promise: Promise<boolean>;
   } | null = null;
-  private inFlightEventSyncById = new Map<
+  private inFlightEventSyncById = new Map<string, Promise<EventSyncResponse>>();
+  private eventSyncParticipantCacheById = new Map<
     string,
-    Promise<{
-      ok: boolean;
-      didChange?: boolean;
-      skipped?: boolean;
-      event?: EventRecord | null;
-    }>
+    EventSyncParticipantMembershipCacheEntry
   >();
+  private eventSyncCooldownCacheById = new Map<
+    string,
+    EventSyncCooldownCacheEntry
+  >();
+  private latestObservedEventById = new Map<string, EventRecord | null>();
+  private activeEventSubscriptionsById = new Map<string, number>();
   private moveSendRequestId = 0;
   private readonly moveSendRetryWindowMs = 60000;
   private readonly moveSendAttemptMaxTimeoutMs = 20000;
@@ -1081,6 +1109,7 @@ class Connection {
     this.didCreateNewGameInvite = false;
     this.newInviteId = "";
     this.optimisticResolvedMatchIds.clear();
+    this.clearEventSyncCaches();
     setCurrentWagerMatch(null);
   }
 
@@ -1090,6 +1119,7 @@ class Connection {
     this.observeMiningFrozen(null);
     this.materialLeaderboardCache.clear();
     this.materialLeaderboardCacheTime = 0;
+    this.clearEventSyncCaches();
   }
 
   public async getProfileByLoginId(loginId: string): Promise<PlayerProfile> {
@@ -2339,15 +2369,19 @@ class Connection {
     }
   }
 
-  public async syncEventState(eventId: string): Promise<{
-    ok: boolean;
-    didChange?: boolean;
-    skipped?: boolean;
-    event?: EventRecord | null;
-  }> {
+  public async syncEventState(eventId: string): Promise<EventSyncResponse> {
     const normalizedEventId = this.normalizeString(eventId).trim();
     if (!normalizedEventId) {
       return { ok: false, skipped: true, event: null };
+    }
+
+    const nowMs = Date.now();
+    const cachedSyncResponse = this.readCachedEventSyncResponse(
+      normalizedEventId,
+      nowMs,
+    );
+    if (cachedSyncResponse) {
+      return cachedSyncResponse;
     }
 
     const existingSync = this.inFlightEventSyncById.get(normalizedEventId);
@@ -2362,8 +2396,19 @@ class Connection {
           this.functions,
           "syncEventState",
         );
-        const maxAttempts = 6;
+        const isParticipant =
+          await this.isLocalProfileEventParticipant(normalizedEventId);
+        if (!isParticipant) {
+          return this.commitEventSyncResponse(normalizedEventId, {
+            ok: true,
+            skipped: true,
+            reason: "not-participant",
+            event: this.latestObservedEventById.get(normalizedEventId) ?? null,
+          });
+        }
 
+        const maxRetries = EVENT_SYNC_RETRY_DELAYS_MS.length;
+        const maxAttempts = maxRetries + 1;
         for (let attempt = 0; attempt < maxAttempts; attempt += 1) {
           const response = await syncEventStateFunction({
             eventId: normalizedEventId,
@@ -2372,26 +2417,37 @@ class Connection {
             ok?: boolean;
             didChange?: unknown;
             skipped?: unknown;
+            reason?: unknown;
             event?: unknown;
           };
+          const reason = this.normalizeEventSyncSkipReason(data?.reason);
           const parsed = {
             ok: data?.ok === true,
             didChange:
               typeof data?.didChange === "boolean" ? data.didChange : undefined,
             skipped:
               typeof data?.skipped === "boolean" ? data.skipped : undefined,
+            reason,
             event: this.mapDatabaseEventRecord(
               data?.event ?? null,
               normalizedEventId,
             ),
           };
-          if (!parsed.skipped || attempt >= maxAttempts - 1) {
-            return parsed;
+          if (
+            !parsed.skipped ||
+            !this.shouldRetryEventSync(parsed.reason) ||
+            attempt >= maxAttempts - 1
+          ) {
+            return this.commitEventSyncResponse(normalizedEventId, parsed);
           }
-          await this.delay(140 * (attempt + 1));
+          await this.delay(EVENT_SYNC_RETRY_DELAYS_MS[attempt] || 300);
         }
 
-        return { ok: false, skipped: true, event: null };
+        return this.commitEventSyncResponse(normalizedEventId, {
+          ok: false,
+          skipped: true,
+          event: null,
+        });
       } catch (error) {
         console.error("Error syncing event state:", error);
         throw error;
@@ -2402,6 +2458,165 @@ class Connection {
 
     this.inFlightEventSyncById.set(normalizedEventId, syncPromise);
     return syncPromise;
+  }
+
+  private shouldRetryEventSync(
+    reason: EventSyncSkipReason | undefined,
+  ): boolean {
+    return reason === "locked" || reason === "rate-limited";
+  }
+
+  private normalizeEventSyncSkipReason(
+    value: unknown,
+  ): EventSyncSkipReason | undefined {
+    if (value === "lock-lost") {
+      return "locked";
+    }
+    if (
+      value === "locked" ||
+      value === "rate-limited" ||
+      value === "not-participant"
+    ) {
+      return value;
+    }
+    return undefined;
+  }
+
+  private isParticipantInEventRecord(
+    eventRecord: EventRecord | null,
+    profileId: string,
+  ): boolean {
+    if (!eventRecord || !eventRecord.participants) {
+      return false;
+    }
+    return !!eventRecord.participants[profileId];
+  }
+
+  private getEventSyncCooldownMs(eventRecord: EventRecord | null): number {
+    if (!eventRecord || eventRecord.status === "scheduled") {
+      return EVENT_SYNC_COOLDOWN_SCHEDULED_MS;
+    }
+    return EVENT_SYNC_COOLDOWN_ACTIVE_MS;
+  }
+
+  private readCachedEventSyncResponse(
+    eventId: string,
+    nowMs: number,
+  ): EventSyncResponse | null {
+    const cacheEntry = this.eventSyncCooldownCacheById.get(eventId);
+    if (!cacheEntry) {
+      return null;
+    }
+    const eventRecord =
+      cacheEntry.response.event ??
+      this.latestObservedEventById.get(eventId) ??
+      null;
+    const cooldownMs = this.getEventSyncCooldownMs(eventRecord);
+    if (nowMs - cacheEntry.responseAtMs >= cooldownMs) {
+      return null;
+    }
+    return cacheEntry.response;
+  }
+
+  private commitEventSyncResponse(
+    eventId: string,
+    response: EventSyncResponse,
+  ): EventSyncResponse {
+    this.eventSyncCooldownCacheById.set(eventId, {
+      responseAtMs: Date.now(),
+      response,
+    });
+    if (response.event !== undefined) {
+      this.latestObservedEventById.set(eventId, response.event ?? null);
+    }
+    return response;
+  }
+
+  private async isLocalProfileEventParticipant(
+    eventId: string,
+  ): Promise<boolean> {
+    const profileId = this.getLocalProfileId();
+    if (!profileId) {
+      // Fail-open when local profile resolution is unavailable; server enforces
+      // participant checks and this avoids suppressing legitimate participant syncs.
+      return true;
+    }
+
+    const cachedMembership = this.eventSyncParticipantCacheById.get(eventId);
+    const nowMs = Date.now();
+    const cacheTtlMs =
+      cachedMembership && cachedMembership.isParticipant
+        ? EVENT_SYNC_PARTICIPANT_CACHE_TTL_MS
+        : EVENT_SYNC_PARTICIPANT_NEGATIVE_CACHE_TTL_MS;
+    if (
+      cachedMembership &&
+      cachedMembership.profileId === profileId &&
+      nowMs - cachedMembership.checkedAtMs <= cacheTtlMs
+    ) {
+      return cachedMembership.isParticipant;
+    }
+
+    const observedEvent = this.latestObservedEventById.get(eventId) ?? null;
+    if (this.isParticipantInEventRecord(observedEvent, profileId)) {
+      this.eventSyncParticipantCacheById.set(eventId, {
+        profileId,
+        checkedAtMs: nowMs,
+        isParticipant: true,
+      });
+      return true;
+    }
+
+    try {
+      const participantSnapshot = await get(
+        ref(this.db, `events/${eventId}/participants/${profileId}`),
+      );
+      const isParticipant = participantSnapshot.exists();
+      const observedEvent = this.latestObservedEventById.get(eventId) ?? null;
+      if (!isParticipant && !observedEvent) {
+        // Fail-open when we do not have an observed event snapshot yet. This
+        // avoids client-side false negatives from stale local profile ids.
+        return true;
+      }
+      this.eventSyncParticipantCacheById.set(eventId, {
+        profileId,
+        checkedAtMs: nowMs,
+        isParticipant,
+      });
+      return isParticipant;
+    } catch {
+      // Fail-open on transient read errors; server-side gate remains authoritative.
+      return true;
+    }
+  }
+
+  private clearEventSyncCaches(): void {
+    this.inFlightEventSyncById.clear();
+    this.eventSyncParticipantCacheById.clear();
+    this.eventSyncCooldownCacheById.clear();
+    this.latestObservedEventById.clear();
+    this.activeEventSubscriptionsById.clear();
+  }
+
+  private clearEventSyncCacheForId(eventId: string): void {
+    this.inFlightEventSyncById.delete(eventId);
+    this.eventSyncParticipantCacheById.delete(eventId);
+    this.eventSyncCooldownCacheById.delete(eventId);
+    this.latestObservedEventById.delete(eventId);
+  }
+
+  private retainEventSubscription(eventId: string): void {
+    const nextCount = (this.activeEventSubscriptionsById.get(eventId) || 0) + 1;
+    this.activeEventSubscriptionsById.set(eventId, nextCount);
+  }
+
+  private releaseEventSubscription(eventId: string): void {
+    const currentCount = this.activeEventSubscriptionsById.get(eventId) || 0;
+    if (currentCount <= 1) {
+      this.activeEventSubscriptionsById.delete(eventId);
+      this.clearEventSyncCacheForId(eventId);
+      return;
+    }
+    this.activeEventSubscriptionsById.set(eventId, currentCount - 1);
   }
 
   public subscribeToEvent(
@@ -2418,6 +2633,7 @@ class Connection {
     let disposed = false;
     let unsubscribe: (() => void) | null = null;
     const sessionGuard = this.createSessionGuard();
+    this.retainEventSubscription(normalizedEventId);
 
     void this.ensureAuthenticated()
       .then(() => {
@@ -2431,12 +2647,16 @@ class Connection {
               return;
             }
             if (!snapshot.exists()) {
+              this.latestObservedEventById.set(normalizedEventId, null);
               onUpdate(null);
               return;
             }
-            onUpdate(
-              this.mapDatabaseEventRecord(snapshot.val(), normalizedEventId),
+            const mappedEvent = this.mapDatabaseEventRecord(
+              snapshot.val(),
+              normalizedEventId,
             );
+            this.latestObservedEventById.set(normalizedEventId, mappedEvent);
+            onUpdate(mappedEvent);
           },
           (error) => {
             if (disposed || !sessionGuard()) {
@@ -2456,6 +2676,7 @@ class Connection {
     return () => {
       disposed = true;
       unsubscribe?.();
+      this.releaseEventSubscription(normalizedEventId);
     };
   }
 

--- a/src/ui/BottomControls.tsx
+++ b/src/ui/BottomControls.tsx
@@ -3223,8 +3223,6 @@ const BottomControls: React.FC = () => {
       },
     );
 
-    void connection.syncEventState(effectiveInviteEventId).catch(() => {});
-
     return () => {
       disposed = true;
       unsubscribe();
@@ -3469,7 +3467,11 @@ const BottomControls: React.FC = () => {
             disabled={isCancelAutomatchDisabled}
             isViewOnly={isCancelAutomatchDisabled}
           >
-            {isCancelAutomatchDisabled ? <ShimmerText>Canceling</ShimmerText> : "Cancel"}
+            {isCancelAutomatchDisabled ? (
+              <ShimmerText>Canceling</ShimmerText>
+            ) : (
+              "Cancel"
+            )}
           </BottomPillButton>
         )}
         {isBotGameButtonVisible && (

--- a/src/ui/EventModal.tsx
+++ b/src/ui/EventModal.tsx
@@ -1725,6 +1725,7 @@ const EventModal: React.FC = () => {
   const openingParticipantIdRef = useRef<string | null>(null);
   const participantLookupSessionRef = useRef(0);
   const ignoreNextBackdropClickRef = useRef(false);
+  const ignoreBackdropMouseDownUntilMsRef = useRef(0);
   const copyResetTimeoutRef = useRef<number | null>(null);
   const topBarRef = useRef<HTMLDivElement | null>(null);
   const bottomBarRef = useRef<HTMLDivElement | null>(null);
@@ -2112,7 +2113,24 @@ const EventModal: React.FC = () => {
       if (event.target !== event.currentTarget) {
         return;
       }
-      ignoreNextBackdropClickRef.current = showsShinyCardSomewhere;
+      const nowMs = Date.now();
+      if (event.type === "touchstart") {
+        // Mobile browsers may fire an emulated mousedown after touchstart.
+        // Ignore that synthetic mousedown so it cannot overwrite this gesture's latch.
+        ignoreBackdropMouseDownUntilMsRef.current = nowMs + 1200;
+      } else if (
+        event.type === "mousedown" &&
+        nowMs <= ignoreBackdropMouseDownUntilMsRef.current
+      ) {
+        return;
+      }
+      const hasShinyCardElement =
+        typeof document !== "undefined" &&
+        document.querySelector('[data-shiny-card="true"]') !== null;
+      ignoreNextBackdropClickRef.current =
+        showsShinyCardSomewhere ||
+        hasShinyCardElement ||
+        !didNotDismissAnythingWithOutsideTapJustNow();
     },
     [],
   );
@@ -2382,8 +2400,8 @@ const EventModal: React.FC = () => {
 
   return (
     <Overlay
-      onMouseDown={handleBackdropPointerDown}
-      onTouchStart={handleBackdropPointerDown}
+      onMouseDownCapture={handleBackdropPointerDown}
+      onTouchStartCapture={handleBackdropPointerDown}
       onClick={handleBackdropClick}
     >
       {modalState.eventId && !isDismissedState && (


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Optimizes event state syncing to cut redundant work and load by throttling server syncs, adding client-side cooldowns and participant checks, and skipping no-op projections. Also fixes accidental event modal dismissal when the ID “shiny card” is visible and adds Cloud Monitoring alert docs.

- **New Features**
  - Server: added per-event sync throttle (500ms), reduced match resolve concurrency to 4, and configured `syncEventState` with higher concurrency/limits; returns skip reasons and logs `event:sync:result` for monitoring.
  - Server: skips event syncs for non-participants by resolving requester participation from event data and auth.
  - Server: `eventProjector` now fingerprints projections to avoid no-op writes; tuned trigger with concurrency/memory.
  - Client: added event sync cooldowns (700ms active, 1500ms scheduled), retries only on `locked`/`rate-limited`, and dedupes in-flight calls; caches participant membership with short TTLs and skips server sync if not a participant.
  - Client: tracks subscriptions to clear per-event sync caches on unsubscribe.
  - Docs: added `docs/cloud-monitoring-alerts.md` and linked from `cloud/README.md` for Functions reliability alerts.

- **Bug Fixes**
  - Event modal: prevents backdrop-triggered dismiss when a shiny ID card is shown; uses capture phase and guards against emulated mouse events after touch.
  - Bottom controls: removes redundant `syncEventState` call on event subscribe; keeps “Canceling” shimmer only while cancel is in progress.

<sup>Written for commit eb7cf16feed6103da2ba21980c1c20cd9cc11ad0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

